### PR TITLE
ocl.c: replace R_ShowMessage with Rprintf

### DIFF
--- a/src/ocl.c
+++ b/src/ocl.c
@@ -216,13 +216,13 @@ attribute_visible SEXP ocl_ez_kernel(SEXP context, SEXP k_name, SEXP code, SEXP 
         if (buffer) {
             build_log_ocl_error = clGetProgramBuildInfo(program, device, CL_PROGRAM_BUILD_LOG, log_len, buffer, NULL);
             if (build_log_ocl_error == CL_SUCCESS)
-                R_ShowMessage(buffer);
+                Rprintf("%s\n", buffer);
             else
                 Rf_warning("clGetProgramBuildInfo failed (with %d)", build_log_ocl_error);
             free(buffer);
         }
         else
-            R_ShowMessage("Could not allocate build log buffer");
+            Rprintf("Could not allocate build log buffer\n");
     }
     if (last_ocl_error != CL_SUCCESS) {
         clReleaseProgram(program);


### PR DESCRIPTION
`R_ShowMessage` is implemented using popup windows on Rgui. On the other hand, `Rprintf` prints to the console (like `R_ShowMessage` on other platforms and Rterm on Windows) and can be trapped using `capture.output`.

I think that use of `Rprintf` in this context will provide better user experience. See also [this R-package-devel thread](https://stat.ethz.ch/pipermail/r-package-devel/2022q4/008769.html).

Unfortunately, I haven't tested this patch further than confirming that the package still passes `R CMD check` on an OpenCL-capable machine. Feel free to implement a different solution to Quirin's problem.