### PR TITLE
Rename the shared library to R_OpenCL

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,4 +1,4 @@
-useDynLib(OpenCL, cl_create_buffer, cl_get_buffer_length,
+useDynLib(R_OpenCL, cl_create_buffer, cl_get_buffer_length,
   cl_read_buffer, cl_write_buffer, ocl_context, ocl_devices,
   ocl_ez_kernel, ocl_get_device_info, ocl_get_platform_info,
   ocl_platforms, ocl_call, ocl_mem_limits, cl_supported_index,

--- a/configure.win
+++ b/configure.win
@@ -68,3 +68,6 @@ echo ''
 
 echo "PKG_CPPFLAGS='$OCLINC'" > src/Makevars.win
 echo "PKG_LIBS='$OCLLIB'" >> src/Makevars.win
+# see src/Makevars for explanation:
+echo 'all: $(SHLIB)' >> src/Makevars.win
+echo '	mv $< R_OpenCL$(SHLIB_EXT)' >> src/Makevars.win

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,3 +1,14 @@
+# Following the example of the 'graph' BioC package:
+# The first target is the one that gets executed by default. By
+# depending on $(SHLIB), we ensure that the shared library is built. We
+# have to rename because it's hard for OpenCL.dll to depend on a
+# different OpenCL.dll on Windows.
+all: $(SHLIB)
+	mv $< R_OpenCL$(SHLIB_EXT)
+# (Note that we can't name our rule R_OpenCL$(SHLIB_EXT) because the
+# variable isn't yet set by the time Make has to evaluate the expression
+# and determine the target name.)
+
 PKG_CFLAGS=$(C_VISIBILITY)
 ## honor PKG_LIBS if supplied, otherwise it's -framework OpenCL on macOS and -lOpenCL elsewhere
 PKG_LIBS:=$(if $(PKG_LIBS),$(PKG_LIBS),$(shell if uname|grep -i darwin >/dev/null; then echo '-framework OpenCL'; else echo '-lOpenCL'; fi))

--- a/src/wrap.c
+++ b/src/wrap.c
@@ -16,7 +16,7 @@ SEXP oclMessageSymbol;
 void R_register_OpenCL(DllInfo *dll);
 
 /* Install symbols */
-attribute_visible void R_init_OpenCL(DllInfo *dll)
+attribute_visible void R_init_R_OpenCL(DllInfo *dll)
 {
     oclDeviceSymbol = Rf_install("device");
     oclQueueSymbol = Rf_install("queue");


### PR DESCRIPTION
This should help with #6. While there may exist tricks combining linker flags and manifests to let an `OpenCL.dll` load another `OpenCL.dll` by name from an unknown system path, a brief reading of [Microsoft documentation](https://learn.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-search-order) didn't suggest any obvious solutions. It may also be possible to change the package to load its DLLs manually in `.onLoad`, first (only on Windows) the system `OpenCL.dll` to resolve it by name, then the package DLL, by full path. Meanwhile, renaming the shared library isn't that much of a change.

I have confirmed that this doesn't break `R CMD check` on a Linux machine, and that the package installs successfully on a Windows 10 machine after setting the `OCL` environment variable once. I can then load the package as usual; it passes the examples and tests.

<details><summary>AMD OpenCL on Windows</summary>

The AMD OpenCL SDK has to be downloaded as a [GitHub release](https://github.com/GPUOpen-LibrariesAndSDKs/OCL-SDK/releases/tag/1.0) from an empty repo. It's not a problem at all to install to a path containing spaces, but for 64-bit systems the SDK uses the `lib/x86_64` subdirectory, while `configure.win` expects to find the `.lib` files in `lib/x64`. I just made a copy with the expected name.
</details>

There are many ways to implement this (e.g. only rename the shared library on Windows, using `#ifdef _WIN32` to give the right name to the DLL entry point), so if you think that the current approach of adding the same code in two different places is not DRY enough, please let me know what you would prefer instead.