### PR TITLE
Add missing headers when ocl.h doesn't include them

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -1,4 +1,5 @@
 #include <string.h>
+#include <stdlib.h>
 #include "ocl.h"
 
 #define USE_RINTERNALS 1

--- a/src/wrap.c
+++ b/src/wrap.c
@@ -1,4 +1,5 @@
 #include "ocl.h"
+#include <stdlib.h>
 
 #include <Rinternals.h>
 #include <R_ext/Visibility.h>


### PR DESCRIPTION
Some distro's OpenCL header (e.g AlmaLinux 9, also applies to any EL Linux like RHEL and Rocky) are conservative and does not transitively include `stdlib.h` so when building on such a platform, we get:

```
* installing to library ‘/root/tmp/libdir’
* installing *source* package ‘OpenCL’ ...
** package ‘OpenCL’ successfully unpacked and MD5 sums checked
** using staged installation
** libs
using C compiler: ‘gcc (GCC) 11.4.1 20231218 (Red Hat 11.4.1-3)’
gcc -I"/root/r/dist/include" -DNDEBUG   -I/usr/local/include '-D_FORTIFY_SOURCE=2'  -fvisibility=hidden -fPIC  -g -O2 -Wall -pedantic -fexceptions -fstack-protector-strong -fstack-clash-protection -Werror=implicit-function-declaration -Wstrict-prototypes   -c buffer.c -o buffer.o
gcc -I"/root/r/dist/include" -DNDEBUG   -I/usr/local/include '-D_FORTIFY_SOURCE=2'  -fvisibility=hidden -fPIC  -g -O2 -Wall -pedantic -fexceptions -fstack-protector-strong -fstack-clash-protection -Werror=implicit-function-declaration -Wstrict-prototypes   -c ocl.c -o ocl.o
gcc -I"/root/r/dist/include" -DNDEBUG   -I/usr/local/include '-D_FORTIFY_SOURCE=2'  -fvisibility=hidden -fPIC  -g -O2 -Wall -pedantic -fexceptions -fstack-protector-strong -fstack-clash-protection -Werror=implicit-function-declaration -Wstrict-prototypes   -c oclerr.c -o oclerr.o
gcc -I"/root/r/dist/include" -DNDEBUG   -I/usr/local/include '-D_FORTIFY_SOURCE=2'  -fvisibility=hidden -fPIC  -g -O2 -Wall -pedantic -fexceptions -fstack-protector-strong -fstack-clash-protection -Werror=implicit-function-declaration -Wstrict-prototypes   -c reg.c -o reg.o
gcc -I"/root/r/dist/include" -DNDEBUG   -I/usr/local/include '-D_FORTIFY_SOURCE=2'  -fvisibility=hidden -fPIC  -g -O2 -Wall -pedantic -fexceptions -fstack-protector-strong -fstack-clash-protection -Werror=implicit-function-declaration -Wstrict-prototypes   -c wrap.c -o wrap.o
wrap.c: In function ‘R2size’:
wrap.c:143:23: error: implicit declaration of function ‘atoll’ [-Werror=implicit-function-declaration]
  143 |         long long l = atoll(c);
      |                       ^~~~~
buffer.c: In function ‘cl_read_buffer’:
buffer.c:197:32: error: implicit declaration of function ‘calloc’ [-Werror=implicit-function-declaration]
  197 |         intermediate = (float*)calloc(XLENGTH(res), sizeof(float));
      |                                ^~~~~~
buffer.c:7:1: note: include ‘<stdlib.h>’ or provide a declaration of ‘calloc’
    6 | #include <R_ext/Visibility.h>
  +++ |+#include <stdlib.h>
    7 | 
buffer.c:197:32: warning: incompatible implicit declaration of built-in function ‘calloc’ [-Wbuiltin-declaration-mismatch]
  197 |         intermediate = (float*)calloc(XLENGTH(res), sizeof(float));
      |                                ^~~~~~
buffer.c:197:32: note: include ‘<stdlib.h>’ or provide a declaration of ‘calloc’
buffer.c:206:13: error: implicit declaration of function ‘free’ [-Werror=implicit-function-declaration]
  206 |             free(intermediate);
      |             ^~~~
buffer.c:206:13: note: include ‘<stdlib.h>’ or provide a declaration of ‘free’
buffer.c:206:13: warning: incompatible implicit declaration of built-in function ‘free’ [-Wbuiltin-declaration-mismatch]
buffer.c:206:13: note: include ‘<stdlib.h>’ or provide a declaration of ‘free’
buffer.c:216:9: warning: incompatible implicit declaration of built-in function ‘free’ [-Wbuiltin-declaration-mismatch]
  216 |         free(intermediate);
      |         ^~~~
buffer.c:216:9: note: include ‘<stdlib.h>’ or provide a declaration of ‘free’
buffer.c: In function ‘cl_write_buffer’:
buffer.c:284:32: warning: incompatible implicit declaration of built-in function ‘calloc’ [-Wbuiltin-declaration-mismatch]
  284 |         intermediate = (float*)calloc(N, sizeof(float));
      |                                ^~~~~~
buffer.c:284:32: note: include ‘<stdlib.h>’ or provide a declaration of ‘calloc’
buffer.c:298:13: warning: incompatible implicit declaration of built-in function ‘free’ [-Wbuiltin-declaration-mismatch]
  298 |             free(intermediate);
      |             ^~~~
buffer.c:298:13: note: include ‘<stdlib.h>’ or provide a declaration of ‘free’
buffer.c:303:9: warning: incompatible implicit declaration of built-in function ‘free’ [-Wbuiltin-declaration-mismatch]
  303 |         free(intermediate);
      |         ^~~~
....  
```

While unverified, I suspect there is a high percentage of users with an NVIDIA OpenCL header which doesn't have this issue because the header is brought in at some point on their side.

This PR simply adds `#include <stdlib.h>` in the two places where's actually used.
With this change,  the package builds on vanilla AlmaLinux 9.4 with just `ocl-icd-devel` (OpenCL headers):

```
* installing to library ‘/root/tmp/libdir’
* installing *source* package ‘OpenCL’ ...
** using staged installation
files ‘src/buffer.c’, ‘src/wrap.c’ have the wrong MD5 checksums
** libs
using C compiler: ‘gcc (GCC) 11.4.1 20231218 (Red Hat 11.4.1-3)’
gcc -I"/root/r/dist/include" -DNDEBUG   -I/usr/local/include '-D_FORTIFY_SOURCE=2'  -fvisibility=hidden -fPIC  -g -O2 -Wall -pedantic -fexceptions -fstack-protector-strong -fstack-clash-protection -Werror=implicit-function-declaration -Wstrict-prototypes   -c wrap.c -o wrap.o
gcc -shared -L/root/r/dist/lib -L/usr/local/lib -o OpenCL.so buffer.o ocl.o oclerr.o reg.o wrap.o -lOpenCL -L/root/r/dist/lib -lR
mv OpenCL.so R_OpenCL.so
installing to /root/tmp/libdir/00LOCK-OpenCL/00new/OpenCL/libs
** R
** byte-compile and prepare package for lazy loading
** help
*** installing help indices
** building package indices
** testing if installed package can be loaded from temporary location
** checking absolute paths in shared objects and dynamic libraries
** testing if installed package can be loaded from final location
** testing if installed package keeps a record of temporary installation path
* DONE (OpenCL)

```

